### PR TITLE
Upgrade deps and use skypack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ router works.
 
 ## Install
 
-You will need to install [packup](https://deno.land/x/packup@v0.0.15) and [twd](https://deno.land/x/twd@v0.4.8).
+You will need to install [packup](https://deno.land/x/packup@v0.1.10) and [twd](https://deno.land/x/twd@v0.4.8).
 
 ```sh
-deno run -A https://deno.land/x/packup@v0.0.15/install.ts
+deno run -A https://deno.land/x/packup@v0.1.10/install.ts
 deno install --allow-read=. --allow-write=. --allow-net=deno.land,esm.sh,cdn.esm.sh -fq https://deno.land/x/twd@v0.4.8/cli.ts
 ```
 

--- a/js/app.tsx
+++ b/js/app.tsx
@@ -1,20 +1,14 @@
-import { React, Route, Switch } from "./deps.ts";
+import { React, Route, Routes } from "./deps.ts";
 import { Navigation } from "./navigation.tsx";
 
 export const App = () => (
   <div>
     <Navigation />
-    <Switch>
-      <Route path="/about">
-        <About />
-      </Route>
-      <Route path="/users">
-        <Users />
-      </Route>
-      <Route path="/">
-        <Home />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route path="/about" element={<About />} />
+      <Route path="/users" element={<Users />} />
+      <Route path="/" element={<Home />} />
+    </Routes>
   </div>
 );
 

--- a/js/deps.ts
+++ b/js/deps.ts
@@ -1,24 +1,24 @@
-import React, { Fragment } from "https://esm.sh/react@17.0.2";
-import ReactDOM from "https://esm.sh/react-dom@17.0.2";
+import React, { Fragment } from "https://cdn.skypack.dev/react@17.0.2";
+import ReactDOM from "https://cdn.skypack.dev/react-dom@17.0.2";
 
 export {
   BrowserRouter,
   Link,
   NavLink,
   Route,
-  Switch,
-} from "https://esm.sh/react-router-dom@5.2.0";
+  Routes,
+} from "https://cdn.skypack.dev/react-router-dom@6.1.1";
 
-export { tw } from "https://esm.sh/twind@0.16.16";
+export { tw } from "https://cdn.skypack.dev/twind@0.16.16";
 export {
   Disclosure,
   Menu,
   Transition,
-} from "https://esm.sh/@headlessui/react@1.4.0";
+} from "https://cdn.skypack.dev/@headlessui/react@1.4.2";
 export {
   BellIcon,
   MenuIcon,
   XIcon,
-} from "https://esm.sh/@heroicons/react@1.0.3/outline";
+} from "https://cdn.skypack.dev/@heroicons/react@1.0.5/outline";
 
 export { Fragment, React, ReactDOM };

--- a/js/deps.ts
+++ b/js/deps.ts
@@ -1,20 +1,21 @@
-import React, { Fragment } from "https://cdn.skypack.dev/react@17.0.2";
-import ReactDOM from "https://cdn.skypack.dev/react-dom@17.0.2";
+import React, { Fragment } from "https://cdn.skypack.dev/react@17.0.2?dts";
+import ReactDOM from "https://cdn.skypack.dev/react-dom@17.0.2?dts";
 
+// @deno-types="https://crux.land/7AEp6g"
 export {
   BrowserRouter,
   Link,
   NavLink,
   Route,
   Routes,
-} from "https://cdn.skypack.dev/react-router-dom@6.1.1";
+} from "https://cdn.skypack.dev/react-router-dom@6.2.1";
 
-export { tw } from "https://cdn.skypack.dev/twind@0.16.16";
+export { tw, setup } from "https://cdn.skypack.dev/twind@0.16.16";
 export {
   Disclosure,
   Menu,
   Transition,
-} from "https://cdn.skypack.dev/@headlessui/react@1.4.2";
+} from "https://cdn.skypack.dev/@headlessui/react@1.4.2?dts";
 export {
   BellIcon,
   MenuIcon,

--- a/js/navigation.tsx
+++ b/js/navigation.tsx
@@ -1,14 +1,14 @@
 import {
   BellIcon,
   Disclosure,
-  Fragment,
   Menu,
   MenuIcon,
   NavLink,
-  React,
   Transition,
   tw,
   XIcon,
+  Fragment,
+  React,
 } from "./deps.ts";
 
 const navigation = [
@@ -71,13 +71,11 @@ export const Navigation = () => (
                     <NavLink
                       key={item.name}
                       to={item.to}
-                      exact
-                      className={classNames(
-                        "text-gray-300 hover:bg-gray-700 hover:text-white",
+                      end
+                      className={({ isActive }) => classNames(
+                        isActive ? "bg-gray-900 text-white" : "text-gray-300 hover:bg-gray-700 hover:text-white",
                         "px-3 py-2 rounded-md text-sm font-medium",
                       )}
-                      activeClassName={tw
-                        `bg-gray-900 hover:bg-gray-900 text-white`}
                     >
                       {item.name}
                     </NavLink>
@@ -183,12 +181,11 @@ export const Navigation = () => (
               <NavLink
                 key={item.name}
                 to={item.to}
-                exact
-                className={classNames(
-                  "text-gray-300 hover:bg-gray-700 hover:text-white",
+                end
+                className={({ isActive }) => classNames(
+                  isActive ? "bg-gray-900 text-white" : "text-gray-300 hover:bg-gray-700 hover:text-white",
                   "block px-3 py-2 rounded-md text-base font-medium",
                 )}
-                activeClassName={tw`bg-gray-900 hover:bg-gray-900 text-white`}
               >
                 {item.name}
               </NavLink>

--- a/twd.ts
+++ b/twd.ts
@@ -1,4 +1,4 @@
-import { Config } from "https://deno.land/x/twd@v0.4.5/types.ts";
+import { Config } from "https://deno.land/x/twd@v0.4.8/types.ts";
 
 export const config: Config = {
   preflight: true,


### PR DESCRIPTION
Not merging this yet because I get a bunch of errors in tsx files when opening the example in visual studio code. The packup and twd commands work though.

The error I get in visual studio code says "JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.deno-ts(7026)". I do not get this error when using esm.sh but packup doesn't work with esm.sh modules.

index.html bundled in 5855ms when using skypack, it took 61419ms when using esm.sh but I get the error "TypeError: can't access property "useState", l3.current is null" in console when I go to http://localhost:1234.

I found that there is a year old issue that skypack pins react to 17.0.1 no matter what version you specify. If I switch esm.sh to using 17.0.1 for react and react-dom, the build only takes around 10 seconds instead of 60. But I get the error "Error: Minified React error #321; visit https://reactjs.org/docs/error-decoder.html?invariant=321 for the full message or use the non-minified dev environment for full errors and additional helpful warnings." in console when I got to http://localhost:1234.

The issue with skypack pinning to 17.0.1 has been around for over a year now. https://github.com/skypackjs/skypack-cdn/issues/88

I'm not sure what is causing issues for esm.sh.