### PR TITLE
Fix live reload script

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -79,8 +79,9 @@ app.addEventListener("listen", ({ hostname, port, secure }) => {
   );
   if (isDevelopment()) {
     fetch("http://localhost:8001/live-reload/trigger", { method: "post" })
-      .catch(() => {
+      .catch((error) => {
         console.log("could not trigger live reload");
+        console.error(error);
       });
   }
 });

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -3,7 +3,6 @@ const bundle = Deno.run({
   env: {
     "DENO_ARGS": "--watch",
   },
-  stderr: "null",
   stdin: "null",
   stdout: "null",
 });
@@ -16,7 +15,6 @@ const liveReload = Deno.run({
     "--config=deno.json",
     "./scripts/live_reload_server.ts",
   ],
-  stderr: "null",
   stdin: "null",
   stdout: "null",
 });

--- a/scripts/live_reload_server.ts
+++ b/scripts/live_reload_server.ts
@@ -25,14 +25,6 @@ function reload(): void {
   }
 })();
 
-(async () => {
-  const watcher = Deno.watchFs("development/public");
-  for await (const event of watcher) {
-    console.log("live reload:", event);
-    reload();
-  }
-})();
-
 const app = new Application();
 const router = new Router()
   .use(async ({ request }, next) => {


### PR DESCRIPTION
https://github.com/KyleJune/deno-tailwind-ui-react-example/pull/13/commits/b921645085b1be315d675ab645a1783aa83949d2 introduced an issue with the live reload server because it moved the live reload script from development/public to public/development. The reason why is because you can't watch files in a directory that does not exist. I didn't notice the issue because the dev.ts script suppressed errors for the bundle command and the live-reload-server.ts.